### PR TITLE
Added module to support auth in RAS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 app/local_settings.py
 db.sqlite3
 .idea
+__pycache__

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,6 @@
 import os
+import jose
+import json
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -100,5 +102,12 @@ def social_url_for(name, **kwargs):
     return login_urls.get(name, name).format(**kwargs)
 
 
+def get_jwt_payload(jwt_obj):
+    """Fetches payload information for a given jwt object. Does not attempt to
+    verify any signatures on the JWT, only returns the payload dict."""
+    return json.loads(jose.jws.verify(jwt_obj, None, [], verify=False))
+
+
 app.context_processor(backends)
 app.jinja_env.globals['url'] = social_url_for
+app.jinja_env.globals['get_jwt_payload'] = get_jwt_payload

--- a/app/ras.py
+++ b/app/ras.py
@@ -24,6 +24,31 @@ class RasOpenIDConnect(OpenIdConnectAuth):
         ('ga4gh_passport_v1', 'ga4gh_passport_v1', True),
     ]
 
+    def get_user_details(self, response):
+        # Only include passports that verify
+        algorithm = self.get_algorithm(response['id_token'])
+        response['ga4gh_passport_v1'] = [
+            passport for passport in response.get('ga4gh_passport_v1', [])
+            if self.verify_jwt(passport, algorithm)
+        ]
+        return super().get_user_details(response)
+
+    def get_algorithm(self, id_token):
+        """Get the algorithm 'alg' set on an id_token header"""
+        header, _, _ = id_token.split('.')
+        return json.loads(base64url_decode(header)).get('alg')
+
+    def verify_jwt(self, jwt, algorithm):
+        """Verifies a jwt and returns the key used to do so. Returns None if
+        verification fails."""
+        message, encoded_sig = jwt.rsplit('.', 1)
+        decoded_sig = base64url_decode(encoded_sig.encode('utf-8'))
+        for key in self.get_jwks_keys():
+            key['alg'] = key.get('alg') or algorithm
+            rsakey = jwk.construct(key)
+            if rsakey.verify(message.encode('utf-8'), decoded_sig):
+                return key
+
     def find_valid_key(self, id_token):
         """
         Currently, 'alg' is not provided in the JWKS keys, which is needed by
@@ -31,16 +56,4 @@ class RasOpenIDConnect(OpenIdConnectAuth):
         field is optional for JWKS keys. The following looks for the 'alg' on
         the id_token if it is not provided in the JWKS keys.
         """
-        # Get signature
-        message, encoded_sig = id_token.rsplit('.', 1)
-        decoded_sig = base64url_decode(encoded_sig.encode('utf-8'))
-        # Get header info
-        header, _ = message.split('.')
-        header_info = json.loads(base64url_decode(header))
-        for key in self.get_jwks_keys():
-            # Fallback on the algorithm set in the id_token header if no
-            # key is specified on the JWKS key
-            key['alg'] = key.get('alg') or header_info.get('alg')
-            rsakey = jwk.construct(key)
-            if rsakey.verify(message.encode('utf-8'), decoded_sig):
-                return key
+        return self.verify_jwt(id_token, self.get_algorithm(id_token))

--- a/app/ras.py
+++ b/app/ras.py
@@ -1,0 +1,20 @@
+from social_core.backends.open_id_connect import OpenIdConnectAuth
+
+
+class RasOpenIDConnect(OpenIdConnectAuth):
+    """
+    RAS OAuth2 implementation in Python Social Auth
+    Required Backend settings are as follows:
+        SOCIAL_AUTH_RAS_KEY = '261c299a-1818-4177-a448-cb4f5602fe6d'
+        SOCIAL_AUTH_RAS_SECRET = '4de57bc2-d15d-4290-98e9-91608ed02ab5'
+    """
+
+    name = 'ras'
+    OIDC_ENDPOINT = 'https://stsstg.nih.gov'
+    DEFAULT_JWKS_ALGORITHM = 'RS256'
+
+    def get_remote_jwks_keys(self):
+        keys = super().get_remote_jwks_keys()
+        for key in keys:
+            key['alg'] = key.get('alg', self.DEFAULT_JWKS_ALGORITHM)
+        return keys

--- a/app/ras.py
+++ b/app/ras.py
@@ -1,3 +1,6 @@
+import json
+from jose import jwk
+from jose.utils import base64url_decode
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 
 
@@ -11,10 +14,33 @@ class RasOpenIDConnect(OpenIdConnectAuth):
 
     name = 'ras'
     OIDC_ENDPOINT = 'https://stsstg.nih.gov'
-    DEFAULT_JWKS_ALGORITHM = 'RS256'
+    EXTRA_DATA = [
+        ('expires_in', 'expires_in', True),
+        ('refresh_token', 'refresh_token', True),
+        ('id_token', 'id_token', True),
+        ('other_tokens', 'other_tokens', True),
+        ('scope', 'scope', True),
+        ('sub', 'sub', True),
+        ('ga4gh_passport_v1', 'ga4gh_passport_v1', True),
+    ]
 
-    def get_remote_jwks_keys(self):
-        keys = super().get_remote_jwks_keys()
-        for key in keys:
-            key['alg'] = key.get('alg', self.DEFAULT_JWKS_ALGORITHM)
-        return keys
+    def find_valid_key(self, id_token):
+        """
+        Currently, 'alg' is not provided in the JWKS keys, which is needed by
+        JOSE to determine the algorithm. This may be a bug, since the 'alg'
+        field is optional for JWKS keys. The following looks for the 'alg' on
+        the id_token if it is not provided in the JWKS keys.
+        """
+        # Get signature
+        message, encoded_sig = id_token.rsplit('.', 1)
+        decoded_sig = base64url_decode(encoded_sig.encode('utf-8'))
+        # Get header info
+        header, _ = message.split('.')
+        header_info = json.loads(base64url_decode(header))
+        for key in self.get_jwks_keys():
+            # Fallback on the algorithm set in the id_token header if no
+            # key is specified on the JWKS key
+            key['alg'] = key.get('alg') or header_info.get('alg')
+            rsakey = jwk.construct(key)
+            if rsakey.verify(message.encode('utf-8'), decoded_sig):
+                return key

--- a/app/settings.py
+++ b/app/settings.py
@@ -14,9 +14,6 @@ SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/'
 SOCIAL_AUTH_USER_MODEL = 'app.models.User'
 SOCIAL_AUTH_STORAGE = 'social_flask_sqlalchemy.models.FlaskStorage'
 SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (
-    'social_core.backends.globus.GlobusOpenIdConnect',
-    # 'social_core.backends.github.GithubOAuth2',
-    # 'social_core.backends.google.GoogleOAuth2',
-    # 'social_core.backends.google.GoogleOpenId',
-    # 'social_core.backends.slack.SlackOAuth2'
+    # 'social_core.backends.globus.GlobusOpenIdConnect',
+    'app.ras.RasOpenIDConnect',
 )

--- a/app/templates/ga4gh_passport.html
+++ b/app/templates/ga4gh_passport.html
@@ -1,0 +1,37 @@
+
+{% for encoded_passport in ga4gh_passport_v1 %}
+{% set passport=get_jwt_payload(encoded_passport) %}
+<h5>General Information</h5>
+<table class="table table-responsive">
+  {% for key, value in passport.items() %}
+  {% if key != 'ga4gh_visa_v1' and key != 'ras_dbgap_permissions' %}
+  <tr>
+    <td>{{key}}</td>
+    <td>{{value}}</td>
+  </tr>
+  {% endif %}
+  {% endfor %}
+</table>
+
+<h5>Visa</h5>
+<table class="table table-responsive">
+  {% for key, value in passport.ga4gh_visa_v1.items() %}
+  <tr>
+    <td>{{key}}</td>
+    <td>{{value if value else 'No Value'}}</td>
+  </tr>
+  {% endfor %}
+</table>
+
+<h5>Permissions</h5>
+<table class="table table-responsive">
+  {% for permission_group in passport.ras_dbgap_permissions %}
+  {% for key, value in permission_group.items() %}
+  <tr>
+    <td>{{key}}</td>
+    <td>{{value if value else 'No Value'}}</td>
+  </tr>
+  {% endfor %}
+  {% endfor %}
+</table>
+{% endfor %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -44,11 +44,6 @@
     <p>This portal integrates RAS Auth.</p>
   </div>
 
-  <div class="alert alert-warning" role="alert">
-    RAS Auth Login is not yet available. The following demonstrates Globus Auth as a placeholder until
-    integrating with RAS is possible.
-  </div>
-
   <div class="card">
     <div class="card-header">Restricted Access</div>
     <div class="card-body">
@@ -74,40 +69,103 @@
   </div>
 
   {% for provider, social_auth_model in associated.items() %}
-    <div class="card my-3">
-      <div class="card-header">User Info -- {{ provider }}</div>
-      <div class="card-body text-break">
-        <table class="table">
-          <tr>
-            <td>Username</td>
-            <td>{{ social_auth_model.user.username }}</td>
-          </tr>
-          <tr>
-            <td>Provider ID</td>
-            <td>{{ social_auth_model.uid }}</td>
-          </tr>
-          <tr>
-            <td>Email</td>
-            <td>{{ social_auth_model.user.email }}</td>
-          </tr>
-          <tr>
-            <td>Extra Data</td>
-            <td>
-              {% for name, value in social_auth_model.extra_data.items() %}
-              {{ name }} --
-              {% if name == 'access_token' or name == 'id_token' %}
-              <strong>Item hidden</strong>
-<!--              <p class="text-break text-small" style="max-width: 800px;">{{ value }}</p>-->
-              {% else %}
-              {{ value }}
-              {% endif %}
-              <br>
+  <div class="card my-3">
+    <div class="card-header">User Info -- {{ provider }}</div>
+    <div class="card-body text-break">
+      <table class="table">
+        <tr>
+          <td>Username</td>
+          <td>{{ social_auth_model.user.username }}</td>
+        </tr>
+        <tr>
+          <td>Provider ID</td>
+          <td>{{ social_auth_model.uid }}</td>
+        </tr>
+        <tr>
+          <td>Email</td>
+          <td>{{ social_auth_model.user.email }}</td>
+        </tr>
+        <tr>
+          <td>Extra Data</td>
+          <td>
+            {% for name, value in social_auth_model.extra_data.items() %}
+            {% if name != 'access_token' and name != 'id_token' and name != 'ga4gh_passport_v1' %}
+            {{ name }} -- {{ value }}<br>
+            {% endif %}
+            {% endfor %}
+          </td>
+        </tr>
+      </table>
+      <div class="accordion" id="authData">
+        <div class="row">
+          <div class="col-2">
+            <p>Raw:</p>
+          </div>
+          <div class="col-8">
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#idTokenCollapse" aria-expanded="true" aria-controls="idTokenCollapse">ID Token</button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#accessToken" aria-expanded="true" aria-controls="accessToken">Access Token</button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#ga4ghPassports" aria-expanded="true" aria-controls="ga4ghPassports">GA4GH Passports</button>
+          </div>
+        </div>
+        <br>
+        <div class="row">
+          <div class="col-2">
+            <p>Formatted:</p>
+          </div>
+          <div class="col-8">
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#idTokenCollapseFormatted" aria-expanded="true" aria-controls="idTokenCollapse">ID Token</button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#accessTokenFormatted" aria-expanded="true" aria-controls="accessToken">Access Token</button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#ga4ghPassportsFormatted" aria-expanded="true" aria-controls="ga4ghPassports">GA4GH Passports</button>
+          </div>
+        </div>
+        <div id="idTokenCollapse" class="collapse" aria-labelledby="headingOne" data-parent="#authData">
+          <div class="card-body">
+            <code>{{social_auth_model.extra_data.id_token}}</code>
+          </div>
+        </div>
+        <div id="accessToken" class="collapse" aria-labelledby="headingOne" data-parent="#authData">
+          <div class="card-body">
+            <code>{{social_auth_model.extra_data.access_token}}</code>
+          </div>
+        </div>
+        <div id="ga4ghPassports" class="collapse" aria-labelledby="headingOne" data-parent="#authData">
+          <div class="card-body">
+            <code>{{social_auth_model.extra_data.ga4gh_passport_v1}}</code>
+          </div>
+        </div>
+        <div id="idTokenCollapseFormatted" class="collapse" aria-labelledby="headingOne" data-parent="#authData">
+          <div class="card-body">
+            <table class="table">
+              {% for key, value in get_jwt_payload(social_auth_model.extra_data.id_token).items() %}
+              <tr>
+                <td>{{key}}</td>
+                <td>{{value}}</td>
+              </tr>
               {% endfor %}
-            </td>
-          </tr>
-        </table>
+            </table>
+          </div>
+        </div>
+        <div id="accessTokenFormatted" class="collapse" aria-labelledby="headingOne" data-parent="#authData">
+          <div class="card-body">
+            <table class="table">
+              {% for key, value in get_jwt_payload(social_auth_model.extra_data.access_token).items() %}
+              <tr>
+                <td>{{key}}</td>
+                <td>{{value}}</td>
+              </tr>
+              {% endfor %}
+            </table>
+          </div>
+        </div>
+        <div id="ga4ghPassportsFormatted" class="collapse" aria-labelledby="headingOne" data-parent="#authData">
+          <div class="card-body">
+            {% set ga4gh_passport_v1=social_auth_model.extra_data.ga4gh_passport_v1 %}
+            {% include 'ga4gh_passport.html' %}
+          </div>
+        </div>
       </div>
     </div>
+  </div>
   {% endfor %}
 
 


### PR DESCRIPTION
The following adds support for RAS and replaces Globus Auth. The OIDC flow works nearly out of the box with PSA, only one significant change was required for the auth module to work, which was due to the 'alg' key not being set on the JWKS.json config here: https://stsstg.nih.gov/openid/connect/jwks.json. Below, I set it to simply assume 'RS256' and that allowed PSA to correctly verify the signature on the token and finish successfully. 'alg' is technically an optional field according to the RFC, so there is likely a proper way to make that assumption -- I'll do another pass to verify. 

The other portion of remaining work is to ensure the additional information returned from the RAS userinfo endpoint is correctly saved to the models, and displayed to the user after login.