### PR TITLE
Changes for RAS v1.1

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import os
 import jose
 import json
+import logging.config
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -28,6 +29,10 @@ try:
     app.config.from_object('app.local_settings')
 except ImportError:
     pass
+
+logging.config.dictConfig(app.config['LOGGING_DICT_CONFIG'])
+log = logging.getLogger(__name__)
+log.debug('Debug logging enabled')
 
 # DB
 engine = create_engine(app.config['SQLALCHEMY_DATABASE_URI'])

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import os
 import jose
 import json
+import requests
 import logging.config
 
 from sqlalchemy import create_engine
@@ -14,6 +15,8 @@ from social_flask.utils import load_strategy
 from social_flask.routes import social_auth
 from social_flask.template_filters import backends
 from social_flask_sqlalchemy.models import init_social
+
+from app.ras import RasOpenIDConnect
 
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -113,6 +116,18 @@ def get_jwt_payload(jwt_obj):
     return json.loads(jose.jws.verify(jwt_obj, None, [], verify=False))
 
 
+def get_userinfo_version():
+    url = RasOpenIDConnect.USERINFO_URL
+    if not url:
+        # This is easier than instantiating RasOpenIDConnect() to fetch the
+        # OIDC config for us.
+        oidc_cfg = 'https://stsstg.nih.gov/.well-known/openid-configuration'
+        url = requests.get(oidc_cfg).json()['userinfo_endpoint']
+    version = url.replace('https://stsstg.nih.gov/openid/connect/', '')
+    return version.replace('/userinfo', '')
+
+
 app.context_processor(backends)
 app.jinja_env.globals['url'] = social_url_for
 app.jinja_env.globals['get_jwt_payload'] = get_jwt_payload
+app.jinja_env.globals['get_userinfo_version'] = get_userinfo_version

--- a/app/settings.py
+++ b/app/settings.py
@@ -17,3 +17,21 @@ SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (
     # 'social_core.backends.globus.GlobusOpenIdConnect',
     'app.ras.RasOpenIDConnect',
 )
+
+LOGGING_DICT_CONFIG = {
+    'version': 1,
+    'formatters': {
+        'basic': {'format': '[%(levelname)s] '
+                            '%(name)s::%(funcName)s() %(message)s'}
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': 'WARNING',
+            'formatter': 'basic',
+        }
+    },
+    'loggers': {
+        'app': {'level': 'DEBUG', 'handlers': ['console']},
+    },
+}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -42,6 +42,9 @@
   <div class="my-3">
     <h3>Researcher Authentication Service Integration</h3>
     <p>This portal integrates RAS Auth.</p>
+    <div class="alert alert-info" role="alert">
+      Configured to use /userinfo version {{ get_userinfo_version() }}
+    </div>
   </div>
 
   <div class="card">


### PR DESCRIPTION
For #3

This basically works for fetching the v1.1 tokens, but I want to do
another pass and make sure a few more things work:

* I need to double check the RAS Passport is being validated correctly
with the correct fields
* The newest implementation isn't backwards compatible with v1.0, I
want to fix that.
* I might change the exception handling a bit, I think auth should fail
if passport information doesn't verify but I want to clean that up a bit.
* I noticed some funny business when requesting the invalid scope
'passport_jwt_v11', where userinfo returned an invalid response. That
may be worth submitting a ticket to RAS if it wasn't a simple mistake
on my end somewhere.

**EDIT**: The above have all been accounted for, minus any mistakes or bugs on my part.